### PR TITLE
feat: 홈페이지에서 팔로워 게시글 피드 불러오기

### DIFF
--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Header from "../../components/Header";
 import HeaderTitle from "../../components/Header/HeaderTitle";
 import Navbar from "../../components/Navbar";
@@ -7,8 +7,26 @@ import PostCard from "../../components/PostCard";
 
 import SearchButton from "../../components/Header/SearchButton";
 import HomeNoFollow from "./HomeNoFollow";
+import axios from "axios";
 
 export default function Home() {
+  const [postList, setPostList] = useState([]);
+  const token = localStorage.getItem("token");
+  const getFollowerPost = async () => {
+    const res = await axios.get(`${process.env.REACT_APP_API_KEY}/post/feed`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-type": "application/json",
+      },
+    });
+
+    setPostList(res.data.posts);
+  };
+
+  useEffect(() => {
+    getFollowerPost();
+  }, []);
+
   return (
     <>
       <Header>
@@ -16,11 +34,13 @@ export default function Home() {
         <SearchButton />
       </Header>
       <MainContainer>
-        {/* <PostCard />
-				<PostCard />
-				<PostCard />
-				<PostCard /> */}
-        <HomeNoFollow />
+        {postList.length > 0 ? (
+          postList.map((post) => {
+            return <PostCard {...post} />;
+          })
+        ) : (
+          <HomeNoFollow />
+        )}
       </MainContainer>
       <Navbar />
     </>


### PR DESCRIPTION
## 🔖 PR 사유

- [x] 기능 추가 : 팔로워 게시글 피드 불러오기
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

<br>


## 📂 작업 대상 파일

- pages/Home

<br>

## 📖 작업 내용

- 홈페이지에서 팔로워 게시글 피드 불러오기


<br>


## 🍀 결과물 스크린샷 (이미지 첨부)

<img width="300" alt="image" src="https://user-images.githubusercontent.com/84954439/208588797-54c0727d-c68f-4ffc-8a04-e748dc803284.png">


<br><br>


## ❔질문사항

- 

<br><br>


## 📌 제안사항

- 
