### PR TITLE
feat: PostDetail 페이지 댓글 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,7 @@ function App() {
         <Route path="/profile/:accountname/following" element={<Follow />} />
         <Route path="/profile/:accountname/follower" element={<Follow />} />
         <Route path="/editprofile" element={<SetProfile />} />
-        <Route path="/postdetail" element={<PostDetail />} />
+        <Route path="/postdetail/:postkey" element={<PostDetail />} />
         <Route path="/postupload" element={<PostUpload />} />
         <Route path="/productupload" element={<ProductUpload />} />
         <Route path="/chatlist" element={<ChatList />} />

--- a/src/components/CommentBar/index.jsx
+++ b/src/components/CommentBar/index.jsx
@@ -1,6 +1,7 @@
-import React from "react";
 import styled from "styled-components";
 import user_img_small from "../../assets/images/user_img_small.svg";
+import axios from "axios";
+import { useState } from "react";
 
 const CommentContainer = styled.div`
   position: fixed;
@@ -35,17 +36,55 @@ const CommentInput = styled.input`
 const CommentBtn = styled.button`
   box-sizing: border-box;
   font-size: 14px;
-  color: #c4c4c4;
+  color: ${(props) => (props.txt ? props.theme.mainColor : "#c4c4c4")};
   width: 5em;
   text-align: center;
 `;
 
-export default function CommentBar() {
+export default function CommentBar({ postkey, setCommentList }) {
+  const token = localStorage.getItem("token");
+  const [txt, setTxt] = useState("");
+
+  const handlePostComment = (e) => {
+    setTxt(e.target.value);
+  };
+
+  const postComment = async () => {
+    try {
+      const res = await axios.post(
+        `${process.env.REACT_APP_API_KEY}/post/${postkey}/comments`,
+        {
+          comment: {
+            content: txt,
+          },
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-type": "application/json",
+          },
+        }
+      );
+      console.log(res.data);
+      setCommentList();
+      setTxt("");
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <CommentContainer>
       <CommentProfileImg src={user_img_small} alt="사용자 이름" />
-      <CommentInput placeholder="댓글 입력하기..." />
-      <CommentBtn>게시</CommentBtn>
+      <CommentInput
+        type="text"
+        placeholder="댓글 입력하기..."
+        onChange={handlePostComment}
+        value={txt}
+      />
+      <CommentBtn onClick={postComment} txt={txt}>
+        게시
+      </CommentBtn>
     </CommentContainer>
   );
 }

--- a/src/pages/PostDetail/Comment.jsx
+++ b/src/pages/PostDetail/Comment.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "styled-components";
 import more_vertical from "../../assets/images/more_vertical.png";
 
@@ -7,13 +6,12 @@ const CommentList = styled.li`
   max-width: 390px;
   display: flex;
   gap: 12px;
-  margin: 0 auto 24px;
+  margin: 0 auto;
   position: relative;
   &:first-child {
-    padding-top: 20px;
+    padding: 20px 16px;
   }
-  border-top: 1px solid #dbdbdb;
-  padding-top: 20px;
+  padding: 16px 16px 0;
 `;
 
 const CommentImg = styled.img`
@@ -39,6 +37,7 @@ const CommentTxt = styled.pre`
   white-space: pre-wrap;
   word-wrap: break-word;
   margin-top: 16px;
+  color: #333;
 `;
 
 const CommentTime = styled.time`
@@ -58,19 +57,18 @@ const CommentVertical = styled.button`
 
 export default function Comment() {
   return (
-    <CommentList>
-      <CommentImg src="https://cdn.pixabay.com/photo/2020/12/16/10/44/cat-5836297_1280.jpg" />
-      <div>
-        <CommentUserName>서귀포시 무슨 무슨 농장</CommentUserName>
-        <CommentTxt>
-          옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
-        </CommentTxt>
-
-        <CommentTime></CommentTime>
-      </div>
-      <CommentVertical>
-        <span className="ir">더보기 버튼</span>
-      </CommentVertical>
-    </CommentList>
+    <>
+      <CommentList>
+        <CommentImg src="https://cdn.pixabay.com/photo/2020/12/16/10/44/cat-5836297_1280.jpg" />
+        <div>
+          <CommentUserName>서귀포시 무슨 무슨 농장</CommentUserName>
+          <CommentTxt />
+          <CommentTime></CommentTime>
+          <CommentVertical>
+            <span className="ir">더보기 버튼</span>
+          </CommentVertical>
+        </div>
+      </CommentList>
+    </>
   );
 }

--- a/src/pages/PostDetail/Comment.jsx
+++ b/src/pages/PostDetail/Comment.jsx
@@ -1,74 +1,25 @@
-import styled from "styled-components";
-import more_vertical from "../../assets/images/more_vertical.png";
+import * as S from "./style";
+import { useState } from "react";
+import axios from "axios";
 
-const CommentList = styled.li`
-  list-style: none;
-  max-width: 390px;
-  display: flex;
-  gap: 12px;
-  margin: 0 auto;
-  position: relative;
-  &:first-child {
-    padding: 20px 16px;
-  }
-  padding: 16px 16px 0;
-`;
-
-const CommentImg = styled.img`
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  object-fit: cover;
-`;
-const CommentUserName = styled.strong`
-  margin-top: 4px;
-  font-size: 14px;
-  display: block;
-  font-weight: 500;
-`;
-
-const CommentTxt = styled.pre`
-  font-size: 14px;
-  margin-bottom: 16px;
-  line-height: 1.4;
-  white-space: -moz-pre-wrap;
-  white-space: -pre-wrap;
-  white-space: -o-pre-wrap;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  margin-top: 16px;
-  color: #333;
-`;
-
-const CommentTime = styled.time`
-  font-size: 10px;
-  color: #767676;
-`;
-
-const CommentVertical = styled.button`
-  position: absolute;
-  top: 12px;
-  right: 0;
-  width: 20px;
-  height: 20px;
-  background-size: 20px;
-  background: center / contain url(${more_vertical}) no-repeat;
-`;
-
-export default function Comment() {
+export default function Comment({
+  data,
+  isMyComment,
+  setDropUpShow,
+  setIsMy,
+  setCommentId,
+}) {
   return (
-    <>
-      <CommentList>
-        <CommentImg src="https://cdn.pixabay.com/photo/2020/12/16/10/44/cat-5836297_1280.jpg" />
-        <div>
-          <CommentUserName>서귀포시 무슨 무슨 농장</CommentUserName>
-          <CommentTxt />
-          <CommentTime></CommentTime>
-          <CommentVertical>
-            <span className="ir">더보기 버튼</span>
-          </CommentVertical>
-        </div>
-      </CommentList>
-    </>
+    <S.CommentList>
+      <S.CommentImg src={data.author.image} />
+      <div>
+        <S.CommentUserName>{data.author.username}</S.CommentUserName>
+        <S.CommentTxt>{data.content}</S.CommentTxt>
+        <S.CommentTime></S.CommentTime>
+        <S.CommentVertical>
+          <span className="ir">더보기 버튼</span>
+        </S.CommentVertical>
+      </div>
+    </S.CommentList>
   );
 }

--- a/src/pages/PostDetail/Comment.jsx
+++ b/src/pages/PostDetail/Comment.jsx
@@ -1,22 +1,43 @@
 import * as S from "./style";
-import { useState } from "react";
-import axios from "axios";
+import { Link } from "react-router-dom";
 
-export default function Comment({
-  data,
-  isMyComment,
-  setDropUpShow,
-  setIsMy,
-  setCommentId,
-}) {
+export default function Comment({ data, setCommentModal }) {
+  const handleCommentModal = () => {
+    setCommentModal(true);
+  };
+
+  const detailDate = (time) => {
+    const milliSeconds = new Date() - time;
+    const seconds = milliSeconds / 1000;
+    if (seconds < 60) return `방금 전`;
+    const minutes = seconds / 60;
+    if (minutes < 60) return `${Math.floor(minutes)}분 전`;
+    const hours = minutes / 60;
+    if (hours < 24) return `${Math.floor(hours)}시간 전`;
+    const days = hours / 24;
+    if (days < 7) return `${Math.floor(days)}일 전`;
+    const weeks = days / 7;
+    if (weeks < 5) return `${Math.floor(weeks)}주 전`;
+    const months = days / 30;
+    if (months < 12) return `${Math.floor(months)}개월 전`;
+    const years = days / 365;
+    return `${Math.floor(years)}년 전`;
+  };
+
+  const nowDate = detailDate(new Date(data.createdAt));
+
   return (
     <S.CommentList>
-      <S.CommentImg src={data.author.image} />
+      <Link to={`/profile/${data.author.accountname}`}>
+        <S.CommentImg src={data.author.image} />
+      </Link>
       <div>
-        <S.CommentUserName>{data.author.username}</S.CommentUserName>
+        <S.CommentUserName>
+          {data.author.username}
+          <S.CommentTime>· {nowDate}</S.CommentTime>
+        </S.CommentUserName>
         <S.CommentTxt>{data.content}</S.CommentTxt>
-        <S.CommentTime></S.CommentTime>
-        <S.CommentVertical>
+        <S.CommentVertical onClick={handleCommentModal}>
           <span className="ir">더보기 버튼</span>
         </S.CommentVertical>
       </div>

--- a/src/pages/PostDetail/UserPostDetail.jsx
+++ b/src/pages/PostDetail/UserPostDetail.jsx
@@ -1,61 +1,15 @@
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
 import PostCard from "../../components/PostCard";
-import axios from "axios";
-import { useParams } from "react-router-dom";
+import * as S from "./style";
 
-// 임시토큰
-export const token =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOWE4MzBkMTdhZTY2NjU4MWM2MDY3OSIsImV4cCI6MTY3NjI1NDU5MSwiaWF0IjoxNjcxMDcwNTkxfQ.gNfhq23b6vEXTbhi4AOOkVN6yAErJBvyUtcX1URypNE";
-
-const CardContainer = styled.div`
-  padding: 0 21px;
-`;
-
-const Line = styled.div`
-  margin: 0 auto;
-  border-bottom: 1px solid ${(props) => props.theme.borderColor};
-  width: 400px;
-`;
-
-export default function UserPostDetail() {
-  const token = localStorage.getItem("token");
-  const [myPostData, setMyPostData] = useState();
-  const { postkey } = useParams();
-  const getPostData = async () => {
-    try {
-      const res = await axios.get(
-        `${process.env.REACT_APP_API_KEY}/post/${postkey}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-type": "application/json",
-          },
-        }
-      );
-      return res.data.post;
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
-  const setPostData = async () => {
-    const res = await getPostData();
-    setMyPostData(res);
-  };
-
-  useEffect(() => {
-    setPostData();
-  }, []);
-
+export default function UserPostDetail({ myPostData }) {
   if (myPostData) {
     return (
       <section>
         <h2 className="ir">사용자가 작성한 게시글</h2>
-        <CardContainer>
+        <S.CardContainer>
           <PostCard {...myPostData} />
-          <Line />
-        </CardContainer>
+          <S.Line />
+        </S.CardContainer>
       </section>
     );
   }

--- a/src/pages/PostDetail/UserPostDetail.jsx
+++ b/src/pages/PostDetail/UserPostDetail.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import PostCard from "../../components/PostCard";
+import axios from "axios";
+import { useParams } from "react-router-dom";
+
+// 임시토큰
+export const token =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOWE4MzBkMTdhZTY2NjU4MWM2MDY3OSIsImV4cCI6MTY3NjI1NDU5MSwiaWF0IjoxNjcxMDcwNTkxfQ.gNfhq23b6vEXTbhi4AOOkVN6yAErJBvyUtcX1URypNE";
+
+const CardContainer = styled.div`
+  padding: 0 21px;
+`;
+
+const Line = styled.div`
+  margin: 0 auto;
+  border-bottom: 1px solid ${(props) => props.theme.borderColor};
+  width: 400px;
+`;
+
+export default function UserPostDetail() {
+  const token = localStorage.getItem("token");
+  const [myPostData, setMyPostData] = useState();
+  const { postkey } = useParams();
+  const getPostData = async () => {
+    try {
+      const res = await axios.get(
+        `${process.env.REACT_APP_API_KEY}/post/${postkey}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-type": "application/json",
+          },
+        }
+      );
+      return res.data.post;
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const setPostData = async () => {
+    const res = await getPostData();
+    setMyPostData(res);
+  };
+
+  useEffect(() => {
+    setPostData();
+  }, []);
+
+  if (myPostData) {
+    return (
+      <section>
+        <h2 className="ir">사용자가 작성한 게시글</h2>
+        <CardContainer>
+          <PostCard {...myPostData} />
+          <Line />
+        </CardContainer>
+      </section>
+    );
+  }
+}

--- a/src/pages/PostDetail/index.jsx
+++ b/src/pages/PostDetail/index.jsx
@@ -8,12 +8,42 @@ import UserPostDetail from "./UserPostDetail";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import { useEffect, useState } from "react";
+import { useRef } from "react";
+import * as S from "./style";
 
 export default function PostDetail() {
-  const token = localStorage.getItem("token");
   const { postkey } = useParams();
   const [comment, setComment] = useState([]);
+  const [myPostData, setMyPostData] = useState();
+  const token = localStorage.getItem("token");
 
+  // UserPostDetail
+  const getPostData = async () => {
+    try {
+      const res = await axios.get(
+        `${process.env.REACT_APP_API_KEY}/post/${postkey}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-type": "application/json",
+          },
+        }
+      );
+      return res.data.post;
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  const setPostData = async () => {
+    const res = await getPostData();
+    setMyPostData(res);
+  };
+
+  useEffect(() => {
+    setPostData();
+  }, []);
+
+  // Comment
   const setCommentList = async () => {
     try {
       const res = await axios.get(
@@ -36,6 +66,31 @@ export default function PostDetail() {
     setCommentList();
   }, []);
 
+  // comment 렌더링
+  const [dropUpShow, setDropUpShow] = useState(false);
+  // const [modalShow, setModalShow] = useState(false);
+  const [isMy, setIsMy] = useState(false);
+  const [commentId, setCommentId] = useState("");
+
+  const clickedComment = useRef();
+
+  // const removeComment = async () => {
+  //   try {
+  //     await axios.delete(
+  //       `${process.env.REACT_APP_API_KEY}/post/${postkey}/comments/${commentId}`,
+  //       {
+  //         headers: {
+  //           Authorization: `Bearer ${token}`,
+  //           "Content-type": "application/json",
+  //         },
+  //       }
+  //     );
+  //     setCommentList();
+  //   } catch (error) {
+  //     console.log(error);
+  //   }
+  // };
+
   return (
     <>
       <Header>
@@ -43,8 +98,18 @@ export default function PostDetail() {
         <Vertical />
       </Header>
       <MainContainer>
-        <UserPostDetail />
-        <Comment />
+        <UserPostDetail myPostData={myPostData} />
+        {comment.map((data) => (
+          <Comment
+            key={data.id}
+            // ref={clickedComment}
+            data={data}
+            // commentId={data.id}
+            // setDropUpShow={setDropUpShow}
+            // setIsMy={setIsMy}
+            // setCommentId={setCommentId}
+          />
+        ))}
       </MainContainer>
       <CommentBar postkey={postkey} setCommentList={setCommentList} />
     </>

--- a/src/pages/PostDetail/index.jsx
+++ b/src/pages/PostDetail/index.jsx
@@ -1,13 +1,41 @@
-import React from "react";
 import Header from "../../components/Header";
 import { MainContainer } from "../../components/MainContainer";
 import Vertical from "../../components/Header/Vertical";
-import PostCard from "../../components/PostCard";
 import Prev from "../../components/Header/Prev";
 import CommentBar from "../../components/CommentBar";
 import Comment from "./Comment";
+import UserPostDetail from "./UserPostDetail";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+import { useEffect, useState } from "react";
 
 export default function PostDetail() {
+  const token = localStorage.getItem("token");
+  const { postkey } = useParams();
+  const [comment, setComment] = useState([]);
+
+  const setCommentList = async () => {
+    try {
+      const res = await axios.get(
+        `${process.env.REACT_APP_API_KEY}/post/${postkey}/comments`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-type": "application/json",
+          },
+        }
+      );
+      const data = res.data.comments;
+      setComment(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    setCommentList();
+  }, []);
+
   return (
     <>
       <Header>
@@ -15,12 +43,10 @@ export default function PostDetail() {
         <Vertical />
       </Header>
       <MainContainer>
-        <PostCard />
-        <Comment />
-        <Comment />
+        <UserPostDetail />
         <Comment />
       </MainContainer>
-      <CommentBar />
+      <CommentBar postkey={postkey} setCommentList={setCommentList} />
     </>
   );
 }

--- a/src/pages/PostDetail/index.jsx
+++ b/src/pages/PostDetail/index.jsx
@@ -8,16 +8,17 @@ import UserPostDetail from "./UserPostDetail";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import { useEffect, useState } from "react";
-import { useRef } from "react";
-import * as S from "./style";
+import PostModal from "../../components/PostModal";
 
 export default function PostDetail() {
   const { postkey } = useParams();
   const [comment, setComment] = useState([]);
+  const [commentId, setCommentId] = useState("");
   const [myPostData, setMyPostData] = useState();
+  const [commentModal, setCommentModal] = useState(false);
   const token = localStorage.getItem("token");
 
-  // UserPostDetail
+  // 게시글 불러오기
   const getPostData = async () => {
     try {
       const res = await axios.get(
@@ -43,7 +44,8 @@ export default function PostDetail() {
     setPostData();
   }, []);
 
-  // Comment
+  // 댓글 리스트 불러오기
+
   const setCommentList = async () => {
     try {
       const res = await axios.get(
@@ -66,28 +68,22 @@ export default function PostDetail() {
     setCommentList();
   }, []);
 
-  // comment 렌더링
-  const [dropUpShow, setDropUpShow] = useState(false);
-  // const [modalShow, setModalShow] = useState(false);
-  const [isMy, setIsMy] = useState(false);
-  const [commentId, setCommentId] = useState("");
+  // 댓글 삭제하기
 
-  const clickedComment = useRef();
-
-  // const removeComment = async () => {
+  // const deleteComment = async (commentId) => {
   //   try {
-  //     await axios.delete(
+  //     const res = await axios.delete(
   //       `${process.env.REACT_APP_API_KEY}/post/${postkey}/comments/${commentId}`,
   //       {
-  //         headers: {
+  //         header: {
   //           Authorization: `Bearer ${token}`,
   //           "Content-type": "application/json",
   //         },
   //       }
   //     );
-  //     setCommentList();
-  //   } catch (error) {
-  //     console.log(error);
+  //     // setCommentList();
+  //   } catch (err) {
+  //     console.error(err);
   //   }
   // };
 
@@ -101,17 +97,14 @@ export default function PostDetail() {
         <UserPostDetail myPostData={myPostData} />
         {comment.map((data) => (
           <Comment
-            key={data.id}
-            // ref={clickedComment}
             data={data}
-            // commentId={data.id}
-            // setDropUpShow={setDropUpShow}
-            // setIsMy={setIsMy}
-            // setCommentId={setCommentId}
+            setCommentModal={setCommentModal}
+            commentModal={commentModal}
           />
         ))}
       </MainContainer>
       <CommentBar postkey={postkey} setCommentList={setCommentList} />
+      {commentModal && <PostModal />}
     </>
   );
 }

--- a/src/pages/PostDetail/style.js
+++ b/src/pages/PostDetail/style.js
@@ -45,6 +45,7 @@ export const CommentTxt = styled.pre`
 export const CommentTime = styled.time`
   font-size: 10px;
   color: #767676;
+  padding-left: 6px;
 `;
 
 export const CommentVertical = styled.button`

--- a/src/pages/PostDetail/style.js
+++ b/src/pages/PostDetail/style.js
@@ -1,0 +1,69 @@
+import styled from "styled-components";
+import more_vertical from "../../assets/images/more_vertical.png";
+
+// Comment
+
+export const CommentList = styled.li`
+  list-style: none;
+  max-width: 358px;
+  display: flex;
+  gap: 12px;
+  margin: 0 auto;
+  position: relative;
+  &:first-child {
+    padding: 20px 16px;
+  }
+  padding: 16px 16px 0;
+`;
+
+export const CommentImg = styled.img`
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+export const CommentUserName = styled.strong`
+  margin-top: 4px;
+  font-size: 14px;
+  display: block;
+  font-weight: 500;
+`;
+
+export const CommentTxt = styled.pre`
+  font-size: 14px;
+  margin-bottom: 16px;
+  line-height: 1.4;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  margin-top: 16px;
+  color: #333;
+`;
+
+export const CommentTime = styled.time`
+  font-size: 10px;
+  color: #767676;
+`;
+
+export const CommentVertical = styled.button`
+  position: absolute;
+  top: 12px;
+  right: 0;
+  width: 20px;
+  height: 20px;
+  background-size: 20px;
+  background: center / contain url(${more_vertical}) no-repeat;
+`;
+
+// UserPostDetail
+export const CardContainer = styled.div`
+  /* padding: 0 21px; */
+`;
+
+export const Line = styled.div`
+  margin-bottom: 20px;
+  border-bottom: 1px solid ${(props) => props.theme.borderColor};
+  /* width: 200vw; */
+`;

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -5,15 +5,17 @@ import { MainContainer } from "../../components/MainContainer";
 import axios from "axios";
 import * as S from "./style";
 import PreviewList from "./PreviewList";
-
-const token = localStorage.getItem("token");
+import { useNavigate, useParams } from "react-router-dom";
 
 const PostUpload = () => {
+  const token = localStorage.getItem("token");
   const [fileName, setFileName] = useState([]);
   const [previewImgUrl, setPreviewImgUrl] = useState([]);
   const [isActive, setIsActive] = useState(false);
   const textRef = useRef();
   const fileRef = useRef();
+  const navigate = useNavigate();
+  const { accountname } = useParams();
 
   const handleResizeHeight = () => {
     textRef.current.style.height = "auto";
@@ -49,12 +51,13 @@ const PostUpload = () => {
             },
           }
         );
-        console.log(res.data);
+        // console.log(res.data);
       } catch (err) {
         console.error(err);
       }
     }
     sendPost();
+    navigate(`/profile/${accountname}`);
   };
 
   // 이미지 파일 업로드

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -5,7 +5,7 @@ import { MainContainer } from "../../components/MainContainer";
 import axios from "axios";
 import * as S from "./style";
 import PreviewList from "./PreviewList";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 
 const PostUpload = () => {
   const token = localStorage.getItem("token");
@@ -51,13 +51,13 @@ const PostUpload = () => {
             },
           }
         );
-        // console.log(res.data);
+        console.log(res.data);
       } catch (err) {
         console.error(err);
       }
     }
     sendPost();
-    navigate(`/profile/${accountname}`);
+    // navigate(`/profile/${accountname}`);
   };
 
   // 이미지 파일 업로드


### PR DESCRIPTION
## 🔖 PR 사유

- [x] 기능 추가 : PostDetail 페이지 댓글 기능 추가
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

<br>


## 📂 작업 대상 파일

- PostDetail 폴더 - index.jsx, UserPostDetail.jsx, style.js
- App.jsx

<br>

## 📖 작업 내용

- 댓글 게시 버튼 클릭 시 POST, PostDetail 페이지에 댓글 게시 가능합니다.
- App.jsx - PostDetail 라우트 수정했습니다. (/postdetail/:postkey)
- 댓글 작성자 프로필 사진 누르면 프로필 페이지로 이동, 댓글 작성 시간 확인 가능합니다.
- 댓글 모달 열기 버튼 누르면 열리기만 합니다. 닫는 기능 구현은 못했습니다..
- 댓글 삭제하기 진행 중입니다..!

<br>


## 🍀 결과물 스크린샷 (이미지 첨부)

<img width="497" alt="스크린샷 2022-12-21 오전 10 08 42" src="https://user-images.githubusercontent.com/108205639/208796799-be86b437-3cbd-4490-8426-6ee189ba80c7.png">


<br><br>


## ❔질문사항

- PostUpload 페이지에서 게시글 업로드 하고 나면 프로필 페이지로 넘어갈 수 있게 navigate(`profile/${accountname}`) 을 했는데 accountname이 undefined가 뜹니다..! const {accountname} = useParams() 사용해서 accountname 변수 사용하는 게 아닌 걸까요...? 

<br><br>


## 📌 제안사항

- 
