### PR TITLE
refactor: 댓글, 게시글, 프리뷰 가져오는 커스텀 훅 완성

### DIFF
--- a/src/hooks/useGetCommentList.js
+++ b/src/hooks/useGetCommentList.js
@@ -1,0 +1,29 @@
+import axios from "axios";
+import { useParams } from "react-router-dom";
+import { useState } from "react";
+
+export const useGetCommentList = () => {
+  const token = localStorage.getItem("token");
+  const { postkey } = useParams();
+  const [comment, setComment] = useState([]);
+
+  const setCommentList = async () => {
+    try {
+      const res = await axios.get(
+        `${process.env.REACT_APP_API_KEY}/post/${postkey}/comments`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-type": "application/json",
+          },
+        }
+      );
+      const data = res.data.comments;
+      setComment(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return { comment, setComment, setCommentList };
+};

--- a/src/hooks/useGetPostData.js
+++ b/src/hooks/useGetPostData.js
@@ -1,0 +1,33 @@
+import axios from "axios";
+import { useParams } from "react-router-dom";
+import { useState } from "react";
+
+export const useGetPostData = () => {
+  const token = localStorage.getItem("token");
+  const { postkey } = useParams();
+  const [myPostData, setMyPostData] = useState();
+
+  const getPostData = async () => {
+    try {
+      const res = await axios.get(
+        `${process.env.REACT_APP_API_KEY}/post/${postkey}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-type": "application/json",
+          },
+        }
+      );
+      return res.data.post;
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const setPostData = async () => {
+    const res = await getPostData();
+    setMyPostData(res);
+  };
+
+  return { getPostData, setPostData, myPostData };
+};

--- a/src/hooks/useGetPreview.js
+++ b/src/hooks/useGetPreview.js
@@ -1,0 +1,33 @@
+import { useState } from "react";
+
+export const useGetPreview = (loadFile) => {
+  const [previewImgUrl, setPreviewImgUrl] = useState([]);
+  const [isActive, setIsActive] = useState(false);
+
+  const getPreview = (loadFile) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(loadFile[0]);
+    reader.onload = () => {
+      setPreviewImgUrl([...previewImgUrl, reader.result]);
+    };
+    setIsActive(true);
+  };
+
+  return { isActive, setIsActive, previewImgUrl, setPreviewImgUrl, getPreview };
+
+  //   const reader = new FileReader();
+  //   reader.readAsDataURL(loadFile[0]);
+  //   reader.onload = () => {
+  //     setPreviewImgUrl(reader.result);
+  //   };
+
+  //   const uploadFile = (e) => {
+  //     const reader = new FileReader();
+  //     reader.readAsDataURL(e.target.files[0]);
+  //     reader.onload = () => {
+  //       setImageSrc(reader.result);
+  //     };
+  //   };
+
+  //   return {};
+};

--- a/src/hooks/useGetPreview.js
+++ b/src/hooks/useGetPreview.js
@@ -14,20 +14,4 @@ export const useGetPreview = (loadFile) => {
   };
 
   return { isActive, setIsActive, previewImgUrl, setPreviewImgUrl, getPreview };
-
-  //   const reader = new FileReader();
-  //   reader.readAsDataURL(loadFile[0]);
-  //   reader.onload = () => {
-  //     setPreviewImgUrl(reader.result);
-  //   };
-
-  //   const uploadFile = (e) => {
-  //     const reader = new FileReader();
-  //     reader.readAsDataURL(e.target.files[0]);
-  //     reader.onload = () => {
-  //       setImageSrc(reader.result);
-  //     };
-  //   };
-
-  //   return {};
 };

--- a/src/pages/PostDetail/Comment.jsx
+++ b/src/pages/PostDetail/Comment.jsx
@@ -66,8 +66,7 @@ export default function Comment({ data, commentId, setCommentList }) {
         }
       );
       setCommentList();
-      setIsModal(false);
-      setIsModalAlert(false);
+      handlCloseClick();
       alert("댓글이 삭제되었습니다.");
     } catch (error) {
       console.log(error);
@@ -93,8 +92,7 @@ export default function Comment({ data, commentId, setCommentList }) {
       );
       console.log(res);
       setCommentList();
-      setIsModal(false);
-      setIsModalAlert(false);
+      handlCloseClick();
       alert("댓글 신고가 완료되었습니다.");
     } catch (error) {
       console.log(error);

--- a/src/pages/PostDetail/index.jsx
+++ b/src/pages/PostDetail/index.jsx
@@ -6,61 +6,18 @@ import CommentBar from "../../components/CommentBar";
 import Comment from "./Comment";
 import UserPostDetail from "./UserPostDetail";
 import { useParams } from "react-router-dom";
-import axios from "axios";
-import { useEffect, useState } from "react";
-import PostModal from "../../components/PostModal";
+import { useEffect } from "react";
+import { useGetCommentList } from "../../hooks/useGetCommentList";
+import { useGetPostData } from "../../hooks/useGetPostData";
 
 export default function PostDetail() {
   const { postkey } = useParams();
-  const [comment, setComment] = useState([]);
-  const [commentId, setCommentId] = useState("");
-  const [myPostData, setMyPostData] = useState();
-  const token = localStorage.getItem("token");
-
-  // 게시글 불러오기
-  const getPostData = async () => {
-    try {
-      const res = await axios.get(
-        `${process.env.REACT_APP_API_KEY}/post/${postkey}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-type": "application/json",
-          },
-        }
-      );
-      return res.data.post;
-    } catch (error) {
-      console.log(error);
-    }
-  };
-  const setPostData = async () => {
-    const res = await getPostData();
-    setMyPostData(res);
-  };
+  const { comment, setCommentList } = useGetCommentList();
+  const { setPostData, myPostData } = useGetPostData();
 
   useEffect(() => {
     setPostData();
   }, []);
-
-  // 댓글 리스트 불러오기
-  const setCommentList = async () => {
-    try {
-      const res = await axios.get(
-        `${process.env.REACT_APP_API_KEY}/post/${postkey}/comments`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-type": "application/json",
-          },
-        }
-      );
-      const data = res.data.comments;
-      setComment(data);
-    } catch (err) {
-      console.error(err);
-    }
-  };
 
   useEffect(() => {
     setCommentList();

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -6,16 +6,19 @@ import axios from "axios";
 import * as S from "./style";
 import PreviewList from "./PreviewList";
 import { Link, useNavigate, useParams } from "react-router-dom";
+import { useGetPreview } from "../../hooks/useGetPreview";
 
 const PostUpload = () => {
   const token = localStorage.getItem("token");
   const [fileName, setFileName] = useState([]);
-  const [previewImgUrl, setPreviewImgUrl] = useState([]);
-  const [isActive, setIsActive] = useState(false);
+  // const [previewImgUrl, setPreviewImgUrl] = useState([]);
+  // const [isActive, setIsActive] = useState(false);
   const textRef = useRef();
   const fileRef = useRef();
   const navigate = useNavigate();
   const { accountname } = useParams();
+  const { isActive, setIsActive, previewImgUrl, setPreviewImgUrl, getPreview } =
+    useGetPreview();
 
   const handleResizeHeight = () => {
     textRef.current.style.height = "auto";
@@ -58,6 +61,7 @@ const PostUpload = () => {
     }
     sendPost();
     // navigate(`/profile/${accountname}`);
+    navigate(`/`);
   };
 
   // 이미지 파일 업로드
@@ -71,14 +75,14 @@ const PostUpload = () => {
   };
 
   // 이미지 파일 미리보기
-  const preview = (loadImg) => {
-    const reader = new FileReader();
-    reader.readAsDataURL(loadImg[0]);
-    reader.onload = () => {
-      setPreviewImgUrl([...previewImgUrl, reader.result]);
-    };
-    setIsActive(true);
-  };
+  // const preview = (loadImg) => {
+  //   const reader = new FileReader();
+  //   reader.readAsDataURL(loadImg[0]);
+  //   reader.onload = () => {
+  //     setPreviewImgUrl([...previewImgUrl, reader.result]);
+  //   };
+  //   setIsActive(true);
+  // };
 
   // 이미지 파일 스트링 데이터 얻기
   const getImgUrl = async (formData, loadImg) => {
@@ -91,7 +95,8 @@ const PostUpload = () => {
         ...fileName,
         `${process.env.REACT_APP_API_KEY}/${res.data[0].filename}`,
       ]);
-      preview(loadImg);
+      // preview(loadImg);
+      getPreview(loadImg);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## 🔖 PR 사유

- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [x] 리팩토링 : 댓글, 게시글, 프리뷰 가져오는 커스텀 훅 완성
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

<br>


## 📂 작업 대상 파일

- useGetCommentList.js, useGetPostData.js , useGetPreview.js 

<br>

## 📖 작업 내용

- 댓글 목록 불러오는 커스텀 훅을 만들었습니다. 
- 게시글을 가져오는 커스텀 훅을 만들었습니다.
- 이미지 프리뷰를 가져오는 커스텀 훅을 만들었습니다.


<br>


## 🍀 결과물 스크린샷 (이미지 첨부)



<br><br>


## ❔질문사항

- 커스텀 훅을 만들어보았는데 이렇게 만드는 게 맞을까요?
- 댓글 삭제 기능이나 댓글 신고 기능도 커스텀 훅으로 만들 수 있을까요?
- useGetPreview를 ProductUpload 페이지에도 적용해보고 싶은데 ProductUpload페이지의 e.target.files 부분과 reader.result 부분이 달라서 어떻게 적용해야할지 모르겠습니다...! 방법이 있을까요..?


<br><br>


## 📌 제안사항

- 