### PR TITLE
feat: 채팅방 페이지 이미지 업로드 및 텍스트 입력 시 전송 버튼 활성화

### DIFF
--- a/src/components/Button/SaveBtn/index.jsx
+++ b/src/components/Button/SaveBtn/index.jsx
@@ -1,0 +1,9 @@
+import { SaveButton } from "./style";
+
+export default function SaveBtn({ isActive, disabled, handleSubmit }) {
+  return (
+    <SaveButton isActive={isActive} disabled={disabled} onClick={handleSubmit}>
+      저장
+    </SaveButton>
+  );
+}

--- a/src/components/Button/SaveBtn/style.js
+++ b/src/components/Button/SaveBtn/style.js
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+
+export const SaveButton = styled.button`
+  background-color: ${(props) =>
+    props.isActive ? props.theme.mainColor : "#90bcff"};
+  color: #fff;
+  margin-left: auto;
+  border-radius: 32px;
+  font-size: 14px;
+  width: 90px;
+  height: 32px;
+`;

--- a/src/components/CommentBar/index.jsx
+++ b/src/components/CommentBar/index.jsx
@@ -6,18 +6,18 @@ import { useState } from "react";
 const CommentContainer = styled.div`
   position: fixed;
   bottom: 0;
-  background-color: white;
+  background-color: #fff;
   display: flex;
   flex-direction: row;
   width: 100%;
-  height: 50px;
+  height: 36px;
   padding: 13px 0;
-  border-top: 0.5px solid rgb(219, 219, 219);
+  border-top: 0.5px solid ${(props) => props.theme.borderColor};
 `;
 
 const CommentProfileImg = styled.img`
-  width: 50px;
-  padding: 0 18px;
+  width: 36px;
+  padding: 0 18px 0 16px;
 `;
 
 const CommentInput = styled.input`

--- a/src/components/Navbar/index.jsx
+++ b/src/components/Navbar/index.jsx
@@ -26,7 +26,7 @@ const Iconli = styled.div`
   gap: 4px;
 `;
 
-const HomeIcon = styled.button`
+const NavIcon = styled.button`
   width: 24px;
   height: 24px;
   &.active {
@@ -93,7 +93,7 @@ export default function Navbar() {
       {navbarData.map((navData) => {
         return (
           <Iconli key={navData.id}>
-            <HomeIcon
+            <NavIcon
               tabImg={navData.tabImg}
               tabActiveImg={navData.tabActiveImg}
               className={navData.match !== null ? "active" : ""}

--- a/src/pages/ChatRoom/ChatBar.jsx
+++ b/src/pages/ChatRoom/ChatBar.jsx
@@ -1,54 +1,86 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import file_gray from "../../assets/images/file_gray.svg";
+import { useRef } from "react";
 
 const ChatContainer = styled.div`
-  /* box-sizing: border-box; */
+  display: flex;
+  vertical-align: center;
+  align-items: center;
   position: fixed;
   bottom: 0;
-  background-color: white;
-  display: flex;
-  flex-direction: row;
+  background-color: #fff;
   width: 100%;
-  height: 50px;
+  height: 36px;
   padding: 13px 0;
-  border-top: 0.5px solid rgb(219, 219, 219);
+  border-top: 0.5px solid ${(props) => props.theme.borderColor};
 `;
 
-const ChatUploadFile = styled.div`
+const ChatUploadFileBtn = styled.button`
   background: center / contain url(${file_gray}) no-repeat;
   background-size: 36px;
-  width: 50px;
+  width: 36px;
+  height: 36px;
   padding: 0 18px;
+  margin: 0 18px 0 16px;
 `;
 
-const ChatInput = styled.input`
+const ChatTextInput = styled.input`
   border: none;
   &:focus {
     outline: none;
   }
   width: 100%;
-
   &::placeholder {
     font-size: 14px;
     color: #c4c4c4;
   }
 `;
 
-const ChattBtn = styled.button`
+const ChatSendBtn = styled.button`
   box-sizing: border-box;
   font-size: 14px;
-  color: #c4c4c4;
+  color: ${(props) =>
+    props.isActive || props.isImgActive ? props.theme.mainColor : "#c4c4c4"};
   width: 5em;
   text-align: center;
+  line-height: 36px;
 `;
 
 export default function CommentBar() {
+  const [isActive, setIsActive] = useState("");
+  const [isImgActive, setIsImgActive] = useState("");
+  const fileRef = useRef();
+
+  const handleClick = () => {
+    fileRef.current.click();
+  };
+
+  const handleImgInput = (e) => {
+    setIsImgActive(e.target.files[0]);
+  };
+
   return (
     <ChatContainer>
-      <ChatUploadFile />
-      <ChatInput placeholder="메세지 입력하기..." />
-      <ChattBtn>전송</ChattBtn>
+      <ChatUploadFileBtn onClick={handleClick} />
+      <input
+        type="file"
+        className="ir"
+        id="post-upload-file"
+        accept="image/*"
+        ref={fileRef}
+        onChange={handleImgInput}
+      />
+
+      <ChatTextInput
+        placeholder="메세지 입력하기..."
+        onChange={(e) => {
+          setIsActive(e.target.value);
+        }}
+      />
+      <ChatSendBtn isActive={isActive} isImgActive={isImgActive}>
+        전송
+      </ChatSendBtn>
     </ChatContainer>
   );
 }

--- a/src/pages/ChatRoom/ChatBar.jsx
+++ b/src/pages/ChatRoom/ChatBar.jsx
@@ -1,51 +1,5 @@
-import React, { useState } from "react";
-import styled from "styled-components";
-import file_gray from "../../assets/images/file_gray.svg";
-import { useRef } from "react";
-
-const ChatContainer = styled.div`
-  display: flex;
-  vertical-align: center;
-  align-items: center;
-  position: fixed;
-  bottom: 0;
-  background-color: #fff;
-  width: 100%;
-  height: 36px;
-  padding: 13px 0;
-  border-top: 0.5px solid ${(props) => props.theme.borderColor};
-`;
-
-const ChatUploadFileBtn = styled.button`
-  background: center / contain url(${file_gray}) no-repeat;
-  background-size: 36px;
-  width: 36px;
-  height: 36px;
-  padding: 0 18px;
-  margin: 0 18px 0 16px;
-`;
-
-const ChatTextInput = styled.input`
-  border: none;
-  &:focus {
-    outline: none;
-  }
-  width: 100%;
-  &::placeholder {
-    font-size: 14px;
-    color: #c4c4c4;
-  }
-`;
-
-const ChatSendBtn = styled.button`
-  box-sizing: border-box;
-  font-size: 14px;
-  color: ${(props) =>
-    props.isActive || props.isImgActive ? props.theme.mainColor : "#c4c4c4"};
-  width: 5em;
-  text-align: center;
-  line-height: 36px;
-`;
+import { useRef, useState } from "react";
+import * as S from "./style";
 
 export default function CommentBar() {
   const [isActive, setIsActive] = useState("");
@@ -61,8 +15,8 @@ export default function CommentBar() {
   };
 
   return (
-    <ChatContainer>
-      <ChatUploadFileBtn onClick={handleClick} />
+    <S.ChatContainer>
+      <S.ChatUploadFileBtn onClick={handleClick} />
       <input
         type="file"
         className="ir"
@@ -72,15 +26,15 @@ export default function CommentBar() {
         onChange={handleImgInput}
       />
 
-      <ChatTextInput
+      <S.ChatTextInput
         placeholder="메세지 입력하기..."
         onChange={(e) => {
           setIsActive(e.target.value);
         }}
       />
-      <ChatSendBtn isActive={isActive} isImgActive={isImgActive}>
+      <S.ChatSendBtn isActive={isActive} isImgActive={isImgActive}>
         전송
-      </ChatSendBtn>
-    </ChatContainer>
+      </S.ChatSendBtn>
+    </S.ChatContainer>
   );
 }

--- a/src/pages/ChatRoom/ChatHeader.jsx
+++ b/src/pages/ChatRoom/ChatHeader.jsx
@@ -1,19 +1,13 @@
-import React from "react";
-import styled from "styled-components";
 import Header from "../../components/Header";
 import ChatVertical from "./ChatVertical";
 import Prev from "../../components/Header/Prev";
-
-const ChatUserName = styled.p`
-  font-size: 14px;
-  font-weight: 500;
-`;
+import * as S from "./style";
 
 export default function ChatHeader() {
   return (
     <Header>
       <Prev />
-      <ChatUserName>애월읍 위니브 감귤농장</ChatUserName>
+      <S.ChatUserName>애월읍 위니브 감귤농장</S.ChatUserName>
       <ChatVertical />
     </Header>
   );

--- a/src/pages/ChatRoom/ChatHeader.jsx
+++ b/src/pages/ChatRoom/ChatHeader.jsx
@@ -13,7 +13,7 @@ export default function ChatHeader() {
   return (
     <Header>
       <Prev />
-      <ChatUserName>파주 불주먹</ChatUserName>
+      <ChatUserName>애월읍 위니브 감귤농장</ChatUserName>
       <Vertical />
     </Header>
   );

--- a/src/pages/ChatRoom/ChatHeader.jsx
+++ b/src/pages/ChatRoom/ChatHeader.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import Header from "../../components/Header";
-import Vertical from "../../components/Header/Vertical";
+import ChatVertical from "./ChatVertical";
 import Prev from "../../components/Header/Prev";
 
 const ChatUserName = styled.p`
@@ -14,7 +14,7 @@ export default function ChatHeader() {
     <Header>
       <Prev />
       <ChatUserName>애월읍 위니브 감귤농장</ChatUserName>
-      <Vertical />
+      <ChatVertical />
     </Header>
   );
 }

--- a/src/pages/ChatRoom/ChatReceive.jsx
+++ b/src/pages/ChatRoom/ChatReceive.jsx
@@ -50,9 +50,9 @@ export default function Chatting() {
         <ReceiveUserImg src="https://cdn.pixabay.com/photo/2020/12/16/10/44/cat-5836297_1280.jpg" />
 
         <ReceiveMessage>
-          안녕하세요 거기 어떤가요? 안녕하세요 거기 어떤가요?안녕하세요 거기
-          어떤가요?안녕하세요 거기 어떤가요?안녕하세요 거기 어떤가요?안녕하세요
-          거기 어떤가요?안녕하세요 거기 어떤가요?
+          옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
+          이상의 청춘의 뼈 따뜻한 그들의 그와 약동하다. 대고, 못할 넣는 풍부하게
+          뛰노는 인생의 힘있다.
         </ReceiveMessage>
 
         <ReceiveTime>17:23</ReceiveTime>

--- a/src/pages/ChatRoom/ChatReceive.jsx
+++ b/src/pages/ChatRoom/ChatReceive.jsx
@@ -1,62 +1,27 @@
-import React from "react";
-import styled from "styled-components";
-
-const ChatReceiveWrapper = styled.div`
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: row;
-  gap: 12px;
-  margin: 9px;
-`;
-
-const ReceiveMessage = styled.p`
-  font-size: 14px;
-  text-align: center;
-  background-color: white;
-  border: 1px solid #c4c4c4;
-  border-radius: 10px;
-  border-top-left-radius: 0;
-  padding: 12px;
-  max-width: 240px;
-  text-align: left;
-  line-height: 18px;
-`;
-
-const ReceiveUserImg = styled.img`
-  height: 42px;
-  width: 42px;
-  border-radius: 50%;
-  object-fit: cover;
-`;
-
-const ReceiveTime = styled.time`
-  font-size: 10px;
-  color: #767676;
-  align-self: flex-end;
-`;
+import * as S from "./style";
 
 export default function Chatting() {
   return (
     <>
-      <ChatReceiveWrapper>
-        <ReceiveUserImg src="https://cdn.pixabay.com/photo/2020/12/16/10/44/cat-5836297_1280.jpg" />
+      <S.ChatReceiveWrapper>
+        <S.ReceiveUserImg src="https://cdn.pixabay.com/photo/2020/12/16/10/44/cat-5836297_1280.jpg" />
 
-        <ReceiveMessage>안녕하세요 거기 어떤가요?</ReceiveMessage>
+        <S.ReceiveMessage>안녕하세요 거기 어떤가요?</S.ReceiveMessage>
 
-        <ReceiveTime>17:23</ReceiveTime>
-      </ChatReceiveWrapper>
+        <S.ReceiveTime>17:23</S.ReceiveTime>
+      </S.ChatReceiveWrapper>
 
-      <ChatReceiveWrapper>
-        <ReceiveUserImg src="https://cdn.pixabay.com/photo/2020/12/16/10/44/cat-5836297_1280.jpg" />
+      <S.ChatReceiveWrapper>
+        <S.ReceiveUserImg src="https://cdn.pixabay.com/photo/2020/12/16/10/44/cat-5836297_1280.jpg" />
 
-        <ReceiveMessage>
+        <S.ReceiveMessage>
           옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
           이상의 청춘의 뼈 따뜻한 그들의 그와 약동하다. 대고, 못할 넣는 풍부하게
           뛰노는 인생의 힘있다.
-        </ReceiveMessage>
+        </S.ReceiveMessage>
 
-        <ReceiveTime>17:23</ReceiveTime>
-      </ChatReceiveWrapper>
+        <S.ReceiveTime>17:23</S.ReceiveTime>
+      </S.ChatReceiveWrapper>
     </>
   );
 }

--- a/src/pages/ChatRoom/ChatSend.jsx
+++ b/src/pages/ChatRoom/ChatSend.jsx
@@ -2,67 +2,66 @@ import React from "react";
 import styled from "styled-components";
 
 const ChatSendWrapper = styled.div`
-	box-sizing: border-box;
-	display: flex;
-	flex-direction: row-reverse;
-	gap: 12px;
-	margin: 9px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 12px;
+  margin: 9px;
 `;
 
 const SendMessage = styled.p`
-	font-size: 14px;
-	text-align: center;
-	background-color: ${(props) => props.theme.mainColor};
-	/* #4d82d4; */
-	border-radius: 10px;
-	border-top-right-radius: 0;
-	padding: 12px;
-	max-width: 240px;
-	text-align: left;
-	line-height: 18px;
-	color: #fff;
+  font-size: 14px;
+  text-align: center;
+  background-color: ${(props) => props.theme.mainColor};
+  border-radius: 10px;
+  border-top-right-radius: 0;
+  padding: 12px;
+  max-width: 240px;
+  text-align: left;
+  line-height: 18px;
+  color: #fff;
 `;
 
 const SendUserImg = styled.img`
-	height: 42px;
-	width: 42px;
-	border-radius: 50%;
-	object-fit: cover;
+  height: 42px;
+  width: 42px;
+  border-radius: 50%;
+  object-fit: cover;
 `;
 
 const SendTime = styled.time`
-	font-size: 10px;
-	color: #767676;
-	align-self: flex-end;
+  font-size: 10px;
+  color: ${(props) => props.theme.grayColor};
+  align-self: flex-end;
 `;
 
 const SendImg = styled.img`
-	width: 240px;
-	height: 240px;
-	border-radius: 10px;
+  width: 240px;
+  height: 240px;
+  border-radius: 10px;
 `;
 
 export default function ChatSend() {
-	return (
-		<>
-			<ChatSendWrapper>
-				<SendUserImg src="https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1686&q=80" />
+  return (
+    <>
+      <ChatSendWrapper>
+        <SendUserImg src="https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1686&q=80" />
 
-				<SendMessage>good</SendMessage>
+        <SendMessage>오늘 눈이 왔어요</SendMessage>
 
-				<SendTime>18:12</SendTime>
-			</ChatSendWrapper>
+        <SendTime>18:12</SendTime>
+      </ChatSendWrapper>
 
-			<ChatSendWrapper>
-				<SendUserImg src="https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1686&q=80" />
+      <ChatSendWrapper>
+        <SendUserImg src="https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1686&q=80" />
 
-				<SendImg
-					src="https://images.unsplash.com/photo-1588943211346-0908a1fb0b01?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1035&q=80"
-					alt=""
-				/>
+        <SendImg
+          src="https://images.unsplash.com/photo-1588943211346-0908a1fb0b01?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1035&q=80"
+          alt=""
+        />
 
-				<SendTime>18:12</SendTime>
-			</ChatSendWrapper>
-		</>
-	);
+        <SendTime>18:12</SendTime>
+      </ChatSendWrapper>
+    </>
+  );
 }

--- a/src/pages/ChatRoom/ChatSend.jsx
+++ b/src/pages/ChatRoom/ChatSend.jsx
@@ -1,67 +1,26 @@
-import React from "react";
-import styled from "styled-components";
-
-const ChatSendWrapper = styled.div`
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: row-reverse;
-  gap: 12px;
-  margin: 9px;
-`;
-
-const SendMessage = styled.p`
-  font-size: 14px;
-  text-align: center;
-  background-color: ${(props) => props.theme.mainColor};
-  border-radius: 10px;
-  border-top-right-radius: 0;
-  padding: 12px;
-  max-width: 240px;
-  text-align: left;
-  line-height: 18px;
-  color: #fff;
-`;
-
-const SendUserImg = styled.img`
-  height: 42px;
-  width: 42px;
-  border-radius: 50%;
-  object-fit: cover;
-`;
-
-const SendTime = styled.time`
-  font-size: 10px;
-  color: ${(props) => props.theme.grayColor};
-  align-self: flex-end;
-`;
-
-const SendImg = styled.img`
-  width: 240px;
-  height: 240px;
-  border-radius: 10px;
-`;
+import * as S from "./style";
 
 export default function ChatSend() {
   return (
     <>
-      <ChatSendWrapper>
-        <SendUserImg src="https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1686&q=80" />
+      <S.ChatSendWrapper>
+        <S.SendUserImg src="https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1686&q=80" />
 
-        <SendMessage>오늘 눈이 왔어요</SendMessage>
+        <S.SendMessage>오늘 눈이 왔어요</S.SendMessage>
 
-        <SendTime>18:12</SendTime>
-      </ChatSendWrapper>
+        <S.SendTime>18:12</S.SendTime>
+      </S.ChatSendWrapper>
 
-      <ChatSendWrapper>
-        <SendUserImg src="https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1686&q=80" />
+      <S.ChatSendWrapper>
+        <S.SendUserImg src="https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1686&q=80" />
 
-        <SendImg
+        <S.SendImg
           src="https://images.unsplash.com/photo-1588943211346-0908a1fb0b01?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1035&q=80"
           alt=""
         />
 
-        <SendTime>18:12</SendTime>
-      </ChatSendWrapper>
+        <S.SendTime>18:12</S.SendTime>
+      </S.ChatSendWrapper>
     </>
   );
 }

--- a/src/pages/ChatRoom/ChatVertical.js
+++ b/src/pages/ChatRoom/ChatVertical.js
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+import css_sprite from "../../assets/images/css_sprites.png";
+import { useModal } from "../../hooks/useModal";
+import ModalContainer from "../../components/Modal/ModalContainer";
+import ModalList from "../../components/Modal/ModalList";
+import { useNavigate } from "react-router-dom";
+
+const VerticalBtn = styled.button`
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  background: url(${css_sprite}) -102px -54px;
+`;
+
+export default function Vertical() {
+  const { isModal, handleModal } = useModal();
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <VerticalBtn onClick={handleModal}>
+        <span className="ir">버티컬 버튼</span>
+      </VerticalBtn>
+      {isModal && (
+        <ModalContainer onClick={handleModal}>
+          <ModalList onClick={() => navigate("/chatlist")}>
+            채팅방 나가기
+          </ModalList>
+        </ModalContainer>
+      )}
+    </>
+  );
+}

--- a/src/pages/ChatRoom/ChatVertical.js
+++ b/src/pages/ChatRoom/ChatVertical.js
@@ -1,16 +1,8 @@
-import styled from "styled-components";
-import css_sprite from "../../assets/images/css_sprites.png";
 import { useModal } from "../../hooks/useModal";
 import ModalContainer from "../../components/Modal/ModalContainer";
 import ModalList from "../../components/Modal/ModalList";
 import { useNavigate } from "react-router-dom";
-
-const VerticalBtn = styled.button`
-  margin-left: auto;
-  width: 24px;
-  height: 24px;
-  background: url(${css_sprite}) -102px -54px;
-`;
+import * as S from "./style";
 
 export default function Vertical() {
   const { isModal, handleModal } = useModal();
@@ -18,9 +10,9 @@ export default function Vertical() {
 
   return (
     <>
-      <VerticalBtn onClick={handleModal}>
+      <S.VerticalBtn onClick={handleModal}>
         <span className="ir">버티컬 버튼</span>
-      </VerticalBtn>
+      </S.VerticalBtn>
       {isModal && (
         <ModalContainer onClick={handleModal}>
           <ModalList onClick={() => navigate("/chatlist")}>

--- a/src/pages/ChatRoom/Chattings.jsx
+++ b/src/pages/ChatRoom/Chattings.jsx
@@ -4,7 +4,7 @@ import ChatReceive from "./ChatReceive";
 import ChatSend from "./ChatSend";
 
 const ChatMain = styled.main`
-  height: calc(100% - 124px);
+  height: calc(100% - 109px);
   position: fixed;
   width: 100%;
   margin-top: 48px;

--- a/src/pages/ChatRoom/style.js
+++ b/src/pages/ChatRoom/style.js
@@ -1,0 +1,138 @@
+import styled from "styled-components";
+import css_sprite from "../../assets/images/css_sprites.png";
+import file_gray from "../../assets/images/file_gray.svg";
+
+// ChatVerticalBtn
+export const VerticalBtn = styled.button`
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  background: url(${css_sprite}) -102px -54px;
+`;
+
+// ChatSend
+export const ChatSendWrapper = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 12px;
+  margin: 9px;
+`;
+
+export const SendMessage = styled.p`
+  font-size: 14px;
+  text-align: center;
+  background-color: ${(props) => props.theme.mainColor};
+  border-radius: 10px;
+  border-top-right-radius: 0;
+  padding: 12px;
+  max-width: 240px;
+  text-align: left;
+  line-height: 18px;
+  color: #fff;
+`;
+
+export const SendUserImg = styled.img`
+  height: 42px;
+  width: 42px;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+export const SendTime = styled.time`
+  font-size: 10px;
+  color: ${(props) => props.theme.grayColor};
+  align-self: flex-end;
+`;
+
+export const SendImg = styled.img`
+  width: 240px;
+  height: 240px;
+  border-radius: 10px;
+`;
+
+// ChatRecieve
+export const ChatReceiveWrapper = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  margin: 9px;
+`;
+
+export const ReceiveMessage = styled.p`
+  font-size: 14px;
+  text-align: center;
+  background-color: white;
+  border: 1px solid #c4c4c4;
+  border-radius: 10px;
+  border-top-left-radius: 0;
+  padding: 12px;
+  max-width: 240px;
+  text-align: left;
+  line-height: 18px;
+`;
+
+export const ReceiveUserImg = styled.img`
+  height: 42px;
+  width: 42px;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+export const ReceiveTime = styled.time`
+  font-size: 10px;
+  color: #767676;
+  align-self: flex-end;
+`;
+
+// ChatHeader
+export const ChatUserName = styled.p`
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+// ChatBar
+export const ChatContainer = styled.div`
+  display: flex;
+  vertical-align: center;
+  align-items: center;
+  position: fixed;
+  bottom: 0;
+  background-color: #fff;
+  width: 100%;
+  height: 36px;
+  padding: 13px 0;
+  border-top: 0.5px solid ${(props) => props.theme.borderColor};
+`;
+
+export const ChatUploadFileBtn = styled.button`
+  background: center / contain url(${file_gray}) no-repeat;
+  background-size: 36px;
+  width: 36px;
+  height: 36px;
+  padding: 0 18px;
+  margin: 0 18px 0 16px;
+`;
+
+export const ChatTextInput = styled.input`
+  border: none;
+  &:focus {
+    outline: none;
+  }
+  width: 100%;
+  &::placeholder {
+    font-size: 14px;
+    color: #c4c4c4;
+  }
+`;
+
+export const ChatSendBtn = styled.button`
+  box-sizing: border-box;
+  font-size: 14px;
+  color: ${(props) =>
+    props.isActive || props.isImgActive ? props.theme.mainColor : "#c4c4c4"};
+  width: 5em;
+  text-align: center;
+  line-height: 36px;
+`;

--- a/src/pages/PostDetail/UserPostDetail.jsx
+++ b/src/pages/PostDetail/UserPostDetail.jsx
@@ -6,10 +6,10 @@ export default function UserPostDetail({ myPostData }) {
     return (
       <section>
         <h2 className="ir">사용자가 작성한 게시글</h2>
-        <S.CardContainer>
+        <div>
           <PostCard {...myPostData} />
           <S.Line />
-        </S.CardContainer>
+        </div>
       </section>
     );
   }

--- a/src/pages/PostDetail/index.jsx
+++ b/src/pages/PostDetail/index.jsx
@@ -24,7 +24,7 @@ export default function PostDetail() {
   useEffect(() => {
     postGetData(postUrl);
     commentGetData(commentUrl);
-    console.log(commentData);
+    // console.log(commentData);
   }, [trigger]);
 
   return (
@@ -38,6 +38,7 @@ export default function PostDetail() {
         {commentData?.comments &&
           commentData?.comments?.map((mapData) => (
             <Comment
+              key={mapData.id}
               data={mapData}
               commentId={mapData.id}
               setTrigger={setTrigger}

--- a/src/pages/PostDetail/style.js
+++ b/src/pages/PostDetail/style.js
@@ -59,12 +59,7 @@ export const CommentVertical = styled.button`
 `;
 
 // UserPostDetail
-export const CardContainer = styled.div`
-  /* padding: 0 21px; */
-`;
-
 export const Line = styled.div`
   margin-bottom: 20px;
   border-bottom: 1px solid ${(props) => props.theme.borderColor};
-  /* width: 200vw; */
 `;

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import Header from "../../components/Header";
 import Prev from "../../components/Header/Prev";
 import { MainContainer } from "../../components/MainContainer";
@@ -10,6 +10,7 @@ import { useGetPreview } from "../../hooks/useGetPreview";
 import { usePostUpload } from "../../hooks/usePostUpload";
 
 const PostUpload = () => {
+  const [disabled, setDisabled] = useState(true);
   const location = useLocation();
   const textRef = useRef();
   const fileRef = useRef();
@@ -25,7 +26,8 @@ const PostUpload = () => {
 
   const handleText = (e) => {
     setTxt(e.target.value);
-    txt !== "" ? setIsActive(true) : setIsActive(false);
+    txt !== "" ? setIsActive(e.target.value) : setIsActive("");
+    e.target.value !== "" ? setDisabled(false) : setDisabled(true);
   };
 
   const handleFile = () => {
@@ -81,11 +83,16 @@ const PostUpload = () => {
       }
     }
   }, []);
+
   return (
     <div>
       <Header>
         <Prev />
-        <S.UploadBtn onClick={handlePostUpload} isActive={isActive}>
+        <S.UploadBtn
+          onClick={handlePostUpload}
+          isActive={isActive}
+          disabled={disabled}
+        >
           업로드
         </S.UploadBtn>
       </Header>

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -53,7 +53,6 @@ const PostUpload = () => {
         ...fileName,
         `${process.env.REACT_APP_API_KEY}/${res.data[0].filename}`,
       ]);
-      // preview(loadImg);
       getPreview(loadImg);
     } catch (err) {
       console.error(err);

--- a/src/pages/PostUpload/style.js
+++ b/src/pages/PostUpload/style.js
@@ -49,8 +49,6 @@ export const UploadContentImg = styled.div`
 export const UploadFileImg = styled.div`
   width: 50px;
   height: 50px;
-  background-image: url(${upload_file}) no-repeat;
-  background-size: 50px;
 `;
 
 export const UploadBtn = styled.button`

--- a/src/pages/PostUpload/style.js
+++ b/src/pages/PostUpload/style.js
@@ -59,6 +59,9 @@ export const UploadBtn = styled.button`
   margin-left: auto;
   width: 90px;
   height: 32px;
+  :disabled {
+    cursor: default;
+  }
 `;
 
 export const UploadFileForm = styled.form`


### PR DESCRIPTION
## 🔖 PR 사유

- [x] 기능 추가 : 채팅방 페이지 이미지 업로드 및 텍스트 입력 시 전송 버튼 활성화, 채팅방 상단 우측 버튼 클릭 시 채팅방 나가기 모달 생성, 게시글 상세 페이지 업로드 버튼 disabled 추가
- [x] 스타일 : 게시글 상세 페이지/채팅방 페이지 style.js 파일 분리
- [x] 리팩토링 : 저장 버튼 컴포넌트로 분리
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

<br>


## 📂 작업 대상 파일

- 

<br>

## 📖 작업 내용

- 채팅방 상단 우측 버튼 클릭 시 채팅방 나가기 모달 뜨게 했습니다.
- 저장 버튼 컴포넌트로 분리했습니다.
- 게시글 상세 페이지/채팅방 페이지 style.js 파일 분리했습니다.
- 게시글 상세 페이지 업로드 버튼 disabled 추가했습니다.


<br>


## 🍀 결과물 스크린샷 (이미지 첨부)
<img width="300" alt="스크린샷 2022-12-26 오전 11 57 23" src="https://user-images.githubusercontent.com/108205639/209513796-14152af5-4931-4b3c-b3ac-b4bf8dec6c6b.png">



<br><br>


## ❔질문사항

- 

<br><br>


## 📌 제안사항

- 
