### PR TITLE
feat: 게시글 업로드 페이지 여러 이미지 미리보기 구현

### DIFF
--- a/src/components/CommentBar/index.jsx
+++ b/src/components/CommentBar/index.jsx
@@ -1,50 +1,7 @@
-import styled from "styled-components";
-import user_img_small from "../../assets/images/user_img_small.svg";
 import axios from "axios";
 import { useState } from "react";
-
-const CommentContainer = styled.div`
-  position: fixed;
-  bottom: 0;
-  background-color: #fff;
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  height: 36px;
-  padding: 13px 0;
-  border-top: 0.5px solid ${(props) => props.theme.borderColor};
-`;
-
-const CommentForm = styled.form`
-  display: flex;
-  width: 100%;
-`;
-
-const CommentProfileImg = styled.img`
-  width: 36px;
-  padding: 0 18px 0 16px;
-`;
-
-const CommentInput = styled.input`
-  border: 0;
-  &:focus {
-    outline: none;
-  }
-  width: 100%;
-
-  &::placeholder {
-    font-size: 14px;
-    color: #c4c4c4;
-  }
-`;
-
-const CommentBtn = styled.button`
-  box-sizing: border-box;
-  font-size: 14px;
-  color: ${(props) => (props.txt ? props.theme.mainColor : "#c4c4c4")};
-  width: 5em;
-  text-align: center;
-`;
+import * as S from "./style";
+import user_img_small from "../../assets/images/user_img_small.svg";
 
 export default function CommentBar({ postkey, setCommentList }) {
   const userInfo = JSON.parse(localStorage.getItem("userinfo"));
@@ -81,17 +38,17 @@ export default function CommentBar({ postkey, setCommentList }) {
   };
 
   return (
-    <CommentContainer>
-      <CommentForm onSubmit={postComment}>
-        <CommentProfileImg src={user_img_small} alt="사용자 이름" />
-        <CommentInput
+    <S.CommentContainer>
+      <S.CommentForm onSubmit={postComment}>
+        <S.CommentProfileImg src={user_img_small} alt="사용자 이름" />
+        <S.CommentInput
           type="text"
           placeholder="댓글 입력하기..."
           onChange={handlePostComment}
           value={txt}
         />
-        <CommentBtn txt={txt}>게시</CommentBtn>
-      </CommentForm>
-    </CommentContainer>
+        <S.CommentBtn txt={txt}>게시</S.CommentBtn>
+      </S.CommentForm>
+    </S.CommentContainer>
   );
 }

--- a/src/components/CommentBar/index.jsx
+++ b/src/components/CommentBar/index.jsx
@@ -1,11 +1,13 @@
 import axios from "axios";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import * as S from "./style";
 import user_img_small from "../../assets/images/user_img_small.svg";
+import { useGetData } from "../../hooks/useGetData";
 
 export default function CommentBar({ postkey, setCommentList }) {
   const userInfo = JSON.parse(localStorage.getItem("userinfo"));
-
+  const { data, getData } = useGetData();
+  const url = `${process.env.REACT_APP_API_KEY}/user/myinfo`;
   const [txt, setTxt] = useState("");
 
   const handlePostComment = (e) => {
@@ -37,10 +39,16 @@ export default function CommentBar({ postkey, setCommentList }) {
     }
   };
 
+  useEffect(() => {
+    getData(url);
+  }, []);
+
   return (
     <S.CommentContainer>
       <S.CommentForm onSubmit={postComment}>
-        <S.CommentProfileImg src={user_img_small} alt="사용자 이름" />
+        {data && (
+          <S.CommentProfileImg src={data.user.image} alt="사용자 이름" />
+        )}
         <S.CommentInput
           type="text"
           placeholder="댓글 입력하기..."

--- a/src/components/CommentBar/index.jsx
+++ b/src/components/CommentBar/index.jsx
@@ -15,6 +15,11 @@ const CommentContainer = styled.div`
   border-top: 0.5px solid ${(props) => props.theme.borderColor};
 `;
 
+const CommentForm = styled.form`
+  display: flex;
+  width: 100%;
+`;
+
 const CommentProfileImg = styled.img`
   width: 36px;
   padding: 0 18px 0 16px;
@@ -50,7 +55,8 @@ export default function CommentBar({ postkey, setCommentList }) {
     setTxt(e.target.value);
   };
 
-  const postComment = async () => {
+  const postComment = async (e) => {
+    e.preventDefault();
     try {
       const res = await axios.post(
         `${process.env.REACT_APP_API_KEY}/post/${postkey}/comments`,
@@ -76,16 +82,16 @@ export default function CommentBar({ postkey, setCommentList }) {
 
   return (
     <CommentContainer>
-      <CommentProfileImg src={user_img_small} alt="사용자 이름" />
-      <CommentInput
-        type="text"
-        placeholder="댓글 입력하기..."
-        onChange={handlePostComment}
-        value={txt}
-      />
-      <CommentBtn onClick={postComment} txt={txt}>
-        게시
-      </CommentBtn>
+      <CommentForm onSubmit={postComment}>
+        <CommentProfileImg src={user_img_small} alt="사용자 이름" />
+        <CommentInput
+          type="text"
+          placeholder="댓글 입력하기..."
+          onChange={handlePostComment}
+          value={txt}
+        />
+        <CommentBtn txt={txt}>게시</CommentBtn>
+      </CommentForm>
     </CommentContainer>
   );
 }

--- a/src/components/CommentBar/style.js
+++ b/src/components/CommentBar/style.js
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+
+export const CommentContainer = styled.div`
+  position: fixed;
+  bottom: 0;
+  background-color: #fff;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 36px;
+  padding: 13px 0;
+  border-top: 0.5px solid ${(props) => props.theme.borderColor};
+`;
+
+export const CommentForm = styled.form`
+  display: flex;
+  width: 100%;
+`;
+
+export const CommentProfileImg = styled.img`
+  width: 36px;
+  padding: 0 18px 0 16px;
+`;
+
+export const CommentInput = styled.input`
+  border: 0;
+  &:focus {
+    outline: none;
+  }
+  width: 100%;
+  &::placeholder {
+    font-size: 14px;
+    color: #c4c4c4;
+  }
+`;
+
+export const CommentBtn = styled.button`
+  box-sizing: border-box;
+  font-size: 14px;
+  color: ${(props) => (props.txt ? props.theme.mainColor : "#c4c4c4")};
+  width: 5em;
+  text-align: center;
+`;

--- a/src/pages/PostUpload/PreviewList.jsx
+++ b/src/pages/PostUpload/PreviewList.jsx
@@ -12,7 +12,6 @@ export default function PreviewList({ mapData, onClick }) {
                 src={image}
                 alt={`${index + 1}번째 업로드 이미지`}
                 length={length}
-                // index={index}
               />
               <S.DeleteBtn id={index} onClick={onClick} type="button" />
             </S.PreviewImgItem>

--- a/src/pages/PostUpload/PreviewList.jsx
+++ b/src/pages/PostUpload/PreviewList.jsx
@@ -1,36 +1,23 @@
-import styled from "styled-components";
-import x from "../../assets/images/x.png";
-
-const PreviewImg = styled.img`
-  position: relative;
-  width: 304px;
-  height: 228px;
-  object-fit: cover;
-  border-radius: 10px;
-`;
-
-const DeleteBtn = styled.button`
-  background: ${`url(${x})`} no-repeat;
-  background-size: 22px;
-  position: relative;
-  bottom: 200px;
-  left: -25px;
-  width: 22px;
-  height: 22px;
-`;
+import * as S from "./style";
 
 export default function PreviewList({ mapData, onClick }) {
+  const length = mapData.length;
   return (
     <>
       {mapData !== null && !!mapData.length && (
-        <ul>
+        <S.PreviewImgList>
           {mapData.map((image, index) => (
-            <li key={index}>
-              <PreviewImg src={image} alt={`${index + 1}번째 업로드 이미지`} />
-              <DeleteBtn id={index} onClick={onClick} type="button" />
-            </li>
+            <S.PreviewImgItem key={index}>
+              <S.PreviewImg
+                src={image}
+                alt={`${index + 1}번째 업로드 이미지`}
+                length={length}
+                // index={index}
+              />
+              <S.DeleteBtn id={index} onClick={onClick} type="button" />
+            </S.PreviewImgItem>
           ))}
-        </ul>
+        </S.PreviewImgList>
       )}
     </>
   );

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -19,6 +19,8 @@ const PostUpload = () => {
     useGetPreview();
   const { fileName, setFileName, txt, setTxt, handlePostUpload } =
     usePostUpload();
+  const { data: profileData, getData: profileGetData } = useGetData();
+  const url = `${process.env.REACT_APP_API_KEY}/user/myinfo`;
 
   const handleResizeHeight = () => {
     textRef.current.style.height = "auto";
@@ -86,9 +88,7 @@ const PostUpload = () => {
     }
   }, []);
 
-  const { data: profileData, getData: profileGetData } = useGetData();
-  const url = `${process.env.REACT_APP_API_KEY}/user/myinfo`;
-
+  // 프로필 이미지 불러오기
   useEffect(() => {
     profileGetData(url);
   }, []);

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -39,9 +39,9 @@ const PostUpload = () => {
     const loadImg = e.target.files;
     const formData = new FormData();
     formData.append("image", loadImg[0]);
-    fileName.length === 0
+    fileName.length < 3
       ? getImgUrl(formData, loadImg)
-      : alert("이미지는 1장만 업로드 가능합니다.");
+      : alert("이미지는 3장만 업로드 가능합니다.");
   };
 
   // 이미지 파일 스트링 데이터 얻기
@@ -124,7 +124,7 @@ const PostUpload = () => {
               accept="image/*"
               ref={fileRef}
               onChange={handleImgInput}
-              // multiple // 이미지 3개 이상
+              multiple
             />
           </S.UploadFileForm>
         </S.UploadContainer>

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -8,6 +8,7 @@ import PreviewList from "./PreviewList";
 import { useLocation } from "react-router-dom";
 import { useGetPreview } from "../../hooks/useGetPreview";
 import { usePostUpload } from "../../hooks/usePostUpload";
+import { useGetData } from "../../hooks/useGetData";
 
 const PostUpload = () => {
   const [disabled, setDisabled] = useState(true);
@@ -30,7 +31,8 @@ const PostUpload = () => {
     e.target.value !== "" ? setDisabled(false) : setDisabled(true);
   };
 
-  const handleFile = () => {
+  const handleFile = (e) => {
+    e.target.file !== "" ? setDisabled(false) : setDisabled(true);
     fileRef.current.click();
   };
 
@@ -84,6 +86,13 @@ const PostUpload = () => {
     }
   }, []);
 
+  const { data: profileData, getData: profileGetData } = useGetData();
+  const url = `${process.env.REACT_APP_API_KEY}/user/myinfo`;
+
+  useEffect(() => {
+    profileGetData(url);
+  }, []);
+
   return (
     <div>
       <Header>
@@ -99,7 +108,9 @@ const PostUpload = () => {
 
       <MainContainer>
         <S.UploadContainer>
-          <S.UploadProfileImg />
+          {profileData && (
+            <S.UploadProfileImg userProfileImg={profileData.user.image} />
+          )}
           <S.UploadContentForm onSubmit={handlePostUpload}>
             <S.UploadText
               name="textarea-uploadpost"

--- a/src/pages/PostUpload/style.js
+++ b/src/pages/PostUpload/style.js
@@ -37,7 +37,6 @@ export const DeleteBtn = styled.button`
 export const UploadContainer = styled.div`
   display: flex;
   padding: 16px;
-  gap: 13px;
   min-height: 100px;
 `;
 
@@ -49,13 +48,17 @@ export const UploadContentForm = styled.form`
 `;
 
 export const UploadProfileImg = styled.div`
-  background: url(${small_profile}) no-repeat;
+  background: ${(props) => `url(${props.userProfileImg})`} no-repeat;
+  background-size: 42px;
+  border-radius: 50%;
+  padding-right: 13px;
   display: block;
   width: 42px;
   height: 42px;
 `;
 
 export const UploadText = styled.textarea`
+  background: none;
   width: 100%;
   border: 0;
   resize: none;
@@ -91,7 +94,7 @@ export const UploadBtn = styled.button`
   margin-left: auto;
   width: 90px;
   height: 32px;
-  :disabled {
+  &:disabled {
     cursor: default;
   }
 `;

--- a/src/pages/PostUpload/style.js
+++ b/src/pages/PostUpload/style.js
@@ -1,7 +1,39 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import small_profile from "../../assets/images/user_img_small.svg";
 import upload_file from "../../assets/images/upload_file.svg";
+import x from "../../assets/images/x.png";
 
+// PreviewList
+export const PreviewImgList = styled.ul`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+`;
+
+export const PreviewImgItem = styled.li`
+  position: relative;
+`;
+
+export const PreviewImg = styled.img`
+  width: 304px;
+  height: 228px;
+  position: relative;
+  object-fit: cover;
+  border-radius: 10px;
+  ${(props) => props.length > 1 && `width: 168px; height: 126px;`}
+`;
+
+export const DeleteBtn = styled.button`
+  background: ${`url(${x})`} no-repeat;
+  background-size: 22px;
+  width: 22px;
+  height: 22px;
+  position: absolute;
+  top: 3px;
+  right: 3px;
+`;
+
+// index.js
 export const UploadContainer = styled.div`
   display: flex;
   padding: 16px;

--- a/src/utils/handleDeclaration.js
+++ b/src/utils/handleDeclaration.js
@@ -25,7 +25,6 @@ export const handleDeclaration = async (
       }
     );
     handlCloseClick();
-    alert("신고가 완료되었습니다.");
   } catch (error) {
     console.log(error);
   }


### PR DESCRIPTION
## 🔖 PR 사유

- [x] 기능 추가 : 게시글 업로드 페이지 여러 이미지 미리보기 구현, 게시글 업로드 페이지에 유저 프로필 이미지 추가, 댓글입력창에 유저 프로필 이미지 추가
- [x] 스타일 : CommentBar 스타일 파일 분리
- [x] 리팩토링 :  CommentBar에 form 추가하여 엔터키 입력 시 제출 가능하게 수정
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

<br>


## 📂 작업 대상 파일

- CommentBar/index.js
- PostUpload/index.js

<br>

## 📖 작업 내용

- 게시글 업로드 페이지 여러 이미지 미리보기 구현
- 게시글 업로드 페이지에 유저 프로필 이미지 추가
- 댓글입력창에 유저 프로필 이미지 추가
- CommentBar 스타일 파일 분리
- CommentBar에 form 추가하여 엔터키 입력 시 제출 가능하게 수정


<br>


## 🍀 결과물 스크린샷 (이미지 첨부)



<br><br>


## ❔질문사항

- 

<br><br>


## 📌 제안사항

- 
