### PR TITLE
style: 게시물 상세/업로드 페이지 유저 프로필 이미지 원형으로 변경

### DIFF
--- a/src/components/CommentBar/index.jsx
+++ b/src/components/CommentBar/index.jsx
@@ -44,21 +44,26 @@ export default function CommentBar({ postkey, setCommentList }) {
   }, []);
 
   return (
-    <S.CommentContainer>
-      <S.CommentForm onSubmit={postComment}>
-        {data ? (
-          <S.CommentProfileImg src={data.user.image} alt={data.user.username} />
-        ) : (
-          <S.CommentProfileImg src={user_img_small} alt="" />
-        )}
-        <S.CommentInput
-          type="text"
-          placeholder="댓글 입력하기..."
-          onChange={handlePostComment}
-          value={txt}
+    <S.CommentForm onSubmit={postComment}>
+      {data ? (
+        <S.CommentProfileImg
+          src={
+            data.user.image.includes("Ellipse")
+              ? user_img_small
+              : data.user.image
+          }
+          alt={data.user.username}
         />
-        <S.CommentBtn txt={txt}>게시</S.CommentBtn>
-      </S.CommentForm>
-    </S.CommentContainer>
+      ) : (
+        <S.CommentProfileImg src={user_img_small} alt="" />
+      )}
+      <S.CommentInput
+        type="text"
+        placeholder="댓글 입력하기..."
+        onChange={handlePostComment}
+        value={txt}
+      />
+      <S.CommentBtn txt={txt}>게시</S.CommentBtn>
+    </S.CommentForm>
   );
 }

--- a/src/components/CommentBar/style.js
+++ b/src/components/CommentBar/style.js
@@ -1,33 +1,31 @@
 import styled from "styled-components";
 
-export const CommentContainer = styled.div`
+export const CommentForm = styled.form`
+  padding: 13px 0px;
   position: fixed;
   bottom: 0;
   background-color: #fff;
   display: flex;
-  flex-direction: row;
+  justify-content: space-between;
   width: 100%;
-  height: 36px;
-  padding: 13px 0;
   border-top: 0.5px solid ${(props) => props.theme.borderColor};
 `;
 
-export const CommentForm = styled.form`
-  display: flex;
-  width: 100%;
-`;
-
 export const CommentProfileImg = styled.img`
+  margin-left: 12px;
   width: 36px;
-  padding: 0 18px 0 16px;
+  height: 36px;
+  border-radius: 50%;
 `;
 
 export const CommentInput = styled.input`
+  flex-grow: 1;
+  margin: 0 18px;
+  height: 36px;
   border: 0;
   &:focus {
     outline: none;
   }
-  width: 100%;
   &::placeholder {
     font-size: 14px;
     color: #c4c4c4;
@@ -35,9 +33,7 @@ export const CommentInput = styled.input`
 `;
 
 export const CommentBtn = styled.button`
-  box-sizing: border-box;
+  margin-right: 20px;
   font-size: 14px;
   color: ${(props) => (props.txt ? props.theme.mainColor : "#c4c4c4")};
-  width: 5em;
-  text-align: center;
 `;

--- a/src/components/Navbar/style.js
+++ b/src/components/Navbar/style.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const IconsUl = styled.ul`
-  background-color: white;
+  background-color: #fff;
   position: fixed;
   bottom: 0;
   left: 0;
@@ -10,7 +10,7 @@ export const IconsUl = styled.ul`
   flex-direction: row;
   justify-content: space-between;
   gap: 14px;
-  border-top: 0.5px solid #dbdbdb;
+  border-top: 0.5px solid ${(props) => props.theme.borderColor};
 `;
 
 export const Iconli = styled.div`
@@ -38,7 +38,7 @@ export const NavIcon = styled.button`
 export const NavSpan = styled.span`
   display: block;
   font-size: 10px;
-  color: #767676;
+  color: ${(props) => props.theme.grayColor};
   &.active {
     color: ${(props) => props.theme.mainColor};
   }

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -95,6 +95,7 @@ const PostUpload = () => {
       }
     }
   }, []);
+
   // 프로필 이미지 불러오기
   useEffect(() => {
     profileGetData(url, "user");
@@ -117,7 +118,11 @@ const PostUpload = () => {
       <MainContainer>
         <S.UploadContainer>
           <S.UploadProfileImg
-            userProfileImg={profileData ? profileData.image : user_img_small}
+            userProfileImg={
+              profileData.image.includes("Ellipse")
+                ? user_img_small
+                : profileData.image
+            }
           />
           <S.UploadContentForm onSubmit={handlePostUpload}>
             <S.UploadText

--- a/src/pages/PostUpload/style.js
+++ b/src/pages/PostUpload/style.js
@@ -43,40 +43,26 @@ export const UploadContentForm = styled.form`
   display: flex;
   flex-direction: column;
   gap: 13px;
-  width: 100%;
+  flex-grow: 1;
 `;
 
 export const UploadProfileImg = styled.div`
   background: ${(props) => `url(${props.userProfileImg})`} no-repeat;
   background-size: 42px;
-  padding-right: 13px;
-  display: block;
   width: 42px;
   height: 42px;
+  border-radius: 50%;
 `;
 
 export const UploadText = styled.textarea`
   background: none;
-  width: 100%;
+  flex-grow: 1;
   border: 0;
   resize: none;
+  margin-left: 12px;
   &:focus {
     outline: none;
   }
-`;
-
-export const UploadContentImg = styled.div`
-  background: ${(props) =>
-    props.uploadImg
-      ? `center / cover
-    url("https://cdn.pixabay.com/photo/2019/12/15/13/01/couple-4697055_1280.jpg")
-    no-repeat`
-      : ""};
-  display: block;
-  width: 300px;
-  height: 200px;
-  border-radius: 20px;
-  margin-top: 16px;
 `;
 
 export const UploadFileImg = styled.div`
@@ -98,12 +84,9 @@ export const UploadBtn = styled.button`
 `;
 
 export const UploadFileForm = styled.form`
-  display: inline-block;
   position: fixed;
   bottom: 16px;
   right: 16px;
   background: url(${upload_file}) no-repeat;
   background-size: 50px;
-  width: 50px;
-  height: 50px;
 `;


### PR DESCRIPTION
## 🔖 PR 사유

- [ ] 기능 추가 : 
- [x] 스타일 :  게시물 상세/업로드 페이지 유저 프로필 이미지 원형으로 변경, navbar 색상 theme에서 가져오도록 변경
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

<br>


## 📂 작업 대상 파일

- src/components/CommentBar/index.jsx
- src/components/CommentBar/style.js
- src/components/Navbar/style.js
- src/pages/PostUpload/index.jsx
- src/pages/PostUpload/style.js

<br>

## 📖 작업 내용

- 게시물 상세/업로드 페이지 유저 프로필 이미지 원형으로 변경했습니다.
- navbar 색상 theme에서 가져오도록 변경했습니다.
- 댓글입력창의 유저 프로필 이미지 로딩될 때 기본 이미지가 뜨도록 변경했습니다.
- 게시글 업로드 페이지의 프로필 이미지 파일명에 Ellipse가 들어가면 기본 이미지가 뜨도록 변경했습니다.


<br>


## 🍀 결과물 스크린샷 (이미지 첨부)

<img width="349" alt="스크린샷 2022-12-29 오후 8 47 32" src="https://user-images.githubusercontent.com/108205639/209947448-f3d2b4a2-bf8d-420c-bc30-626ecc78321e.png">
<img width="345" alt="스크린샷 2022-12-29 오후 8 47 47" src="https://user-images.githubusercontent.com/108205639/209947452-ee07797c-7c9c-42cc-ac34-8d3e3e133e85.png">



<br><br>


## ❔질문사항

- 

<br><br>


## 📌 제안사항

- 
