### PR TITLE
fix: 지도 설정 하지 않은 후 게시글 등록시 글자 깨지는 현상 수정

### DIFF
--- a/src/components/PostCard/index.jsx
+++ b/src/components/PostCard/index.jsx
@@ -62,7 +62,7 @@ export default function PostCard({
         <S.PostCardContentContainer>
           <S.PostCardUserName>{author.username}</S.PostCardUserName>
           <S.PostCardUserId>&#64;{author.accountname}</S.PostCardUserId>
-          {content.includes('"map":{') ? (
+          {content.includes('"map":') ? (
             <S.PostCardContentTxt>
               {JSON.parse(content).content}
             </S.PostCardContentTxt>


### PR DESCRIPTION
## 🔖 PR 사유

- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : 게시글 등록시  지도 설정 하지 않은 후 게시글 등록시 글자 깨지는 현상 수정
- [ ] 기타 : 

<br>


## 📂 작업 대상 파일

- src/components/PostCard/index.jsx

<br>

## 📖 작업 내용

- 게시글 등록시  지도 설정 하지 않은 후 게시글 등록시 글자 깨지는 현상 수정


<br>


## 🍀 결과물 스크린샷 (이미지 첨부)



<br><br>


## ❔질문사항

- 

<br><br>


## 📌 제안사항

- 
