### PR TITLE
refactor: 홈, 프로필, 검색, 팔로우의 데이터 변수명 변경

### DIFF
--- a/src/pages/Follow/index.jsx
+++ b/src/pages/Follow/index.jsx
@@ -14,20 +14,25 @@ import { useObserver } from "../../hooks/useObserver";
 export default function Follow() {
   const [triggerFollow, setTriggerFollow] = useState(false);
   const curRef = useRef(null);
-  const { data, isLoading, getData, page, reloading, finishReload } =
-    useObserver(curRef, 15);
+  const {
+    data: folloData,
+    isLoading,
+    getData: getFollowData,
+    page,
+    reloading,
+    finishReload,
+  } = useObserver(curRef, 15);
   const { accountname } = useParams();
   const path = useLocation();
-
   const followingUrl = `${process.env.REACT_APP_API_KEY}/profile/${accountname}/following/?limit=15&skip=${page}`;
   const followerUrl = `${process.env.REACT_APP_API_KEY}/profile/${accountname}/follower/?limit=15&skip=${page}`;
 
   useEffect(() => {
     if (!finishReload) {
       if (path.pathname.includes("follower")) {
-        getData(followerUrl);
+        getFollowData(followerUrl);
       } else {
-        getData(followingUrl);
+        getFollowData(followingUrl);
       }
     }
   }, [triggerFollow, page]);
@@ -44,7 +49,7 @@ export default function Follow() {
             <LoadingPage />
           ) : (
             <>
-              {data.map((follow) => (
+              {folloData.map((follow) => (
                 <S.ProfileLink key={follow._id}>
                   <Link to={`/profile/${follow.accountname}`}>
                     <UserInfo {...follow} />

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -12,13 +12,18 @@ import { useObserver } from "../../hooks/useObserver";
 
 export default function Home() {
   const curRef = useRef(null);
-  const { data, isLoading, getData, page, reloading, finishReload } =
-    useObserver(curRef, 10);
+  const {
+    data: feedData,
+    isLoading,
+    getData: getFeedData,
+    page,
+    reloading,
+    finishReload,
+  } = useObserver(curRef, 10);
   const url = `${process.env.REACT_APP_API_KEY}/post/feed/?limit=10&skip=${page}`;
-
   useEffect(() => {
     if (!finishReload) {
-      getData(url, "posts");
+      getFeedData(url, "posts");
     }
   }, [page]);
 
@@ -32,10 +37,10 @@ export default function Home() {
       <MainContainer>
         {isLoading ? (
           <LoadingPage />
-        ) : data.length > 0 ? (
+        ) : feedData.length > 0 ? (
           <>
             <ul>
-              {data.map((post) => {
+              {feedData.map((post) => {
                 return <PostCard key={post.id} {...post} />;
               })}
             </ul>

--- a/src/pages/Profile/BottomSection.jsx
+++ b/src/pages/Profile/BottomSection.jsx
@@ -17,17 +17,16 @@ export default function ProfileBottomSection() {
 
   const curRef = useRef(null);
   const {
-    data,
+    data: postData,
     isLoading,
-    getData,
+    getData: getPostData,
     page,
     reloading,
     finishReload,
     setPage,
     setFinishReload,
-    setData,
+    setData: setPostData,
   } = useObserver(curRef, 5);
-
   const listUrl = `${process.env.REACT_APP_API_KEY}/post/${accountname}/userpost/?limit=5&skip=${page}`;
   const albumUrl = `${process.env.REACT_APP_API_KEY}/post/${accountname}/userpost/?limit=50`;
 
@@ -43,7 +42,7 @@ export default function ProfileBottomSection() {
 
   useEffect(() => {
     if (!finishReload) {
-      getData(listUrl, "post");
+      getPostData(listUrl, "post");
     }
   }, [page, accountname]);
   return (
@@ -76,8 +75,8 @@ export default function ProfileBottomSection() {
             })
         ) : (
           <>
-            {data.map((post) => {
-              return <PostCard key={post.id} setData={setData} {...post} />;
+            {postData.map((post) => {
+              return <PostCard key={post.id} setData={setPostData} {...post} />;
             })}
             <div ref={curRef}></div>
           </>

--- a/src/pages/Profile/MidSection.jsx
+++ b/src/pages/Profile/MidSection.jsx
@@ -5,21 +5,26 @@ import { useGetData } from "../../hooks/useGetData";
 import * as S from "./style";
 
 export default function ProfileMidSection() {
-  const { data, isLoading, getData, setData } = useGetData();
+  const {
+    data: productData,
+    isLoading,
+    getData: getProductData,
+    setData: setProductData,
+  } = useGetData();
   const { accountname } = useParams();
   const url = `${process.env.REACT_APP_API_KEY}/product/${accountname}`;
   useEffect(() => {
-    getData(url, "product");
+    getProductData(url, "product");
   }, [accountname]);
-  return isLoading ? null : data.length > 0 ? (
+  return isLoading ? null : productData.length > 0 ? (
     <S.ProfileMidSec>
       <S.ProfileMidSectionCon>
         <S.ProfileMidSectionH2>판매중인 상품</S.ProfileMidSectionH2>
         <S.ProfileMidSectionUl>
-          {data.map((product) => {
+          {productData.map((product) => {
             return (
               <ProductCard
-                setData={setData}
+                setData={setProductData}
                 accountname={accountname}
                 productId={product.id}
                 productLink={product.link}

--- a/src/pages/Profile/TopSection.jsx
+++ b/src/pages/Profile/TopSection.jsx
@@ -8,14 +8,18 @@ import * as S from "./style";
 import LoadingPage from "../LoadingPage";
 
 export default function ProfileTopSection() {
-  const { data, setData, isLoading, getData } = useGetData();
+  const {
+    data: profileInfo,
+    setData: setProfileInfo,
+    isLoading,
+    getData: getProfileInfo,
+  } = useGetData();
   const userInfo = JSON.parse(localStorage.getItem("userinfo"));
   const { accountname } = useParams();
   const isMyProfile = accountname === userInfo.accountname;
   const url = `${process.env.REACT_APP_API_KEY}/profile/${accountname}`;
-
   useEffect(() => {
-    getData(url, "profile");
+    getProfileInfo(url, "profile");
   }, [accountname]);
 
   return isLoading ? (
@@ -25,31 +29,41 @@ export default function ProfileTopSection() {
       <h2 className="ir">프로필 수정 및 상품등록</h2>
       <S.ProfileTopContainer>
         <S.ProfileImgFollowBtnsCon>
-          <S.ProfileFollowers to={`/profile/${data.accountname}/follower`}>
-            <S.ProfileFollowCount>{data.followerCount}</S.ProfileFollowCount>
+          <S.ProfileFollowers
+            to={`/profile/${profileInfo.accountname}/follower`}
+          >
+            <S.ProfileFollowCount>
+              {profileInfo.followerCount}
+            </S.ProfileFollowCount>
             <S.ProfileFollowTxt>followers</S.ProfileFollowTxt>
           </S.ProfileFollowers>
           <S.ProfileUserImg
-            src={data.image.includes("Ellipse") ? user_img_big : data.image}
+            src={
+              profileInfo.image.includes("Ellipse")
+                ? user_img_big
+                : profileInfo.image
+            }
             alt="프로필 이미지"
           />
-          <S.ProfileFollowers to={`/profile/${data.accountname}/following`}>
+          <S.ProfileFollowers
+            to={`/profile/${profileInfo.accountname}/following`}
+          >
             <S.ProfileFollowCount isfollowing="1">
-              {data.followingCount}
+              {profileInfo.followingCount}
             </S.ProfileFollowCount>
             <S.ProfileFollowTxt>following</S.ProfileFollowTxt>
           </S.ProfileFollowers>
         </S.ProfileImgFollowBtnsCon>
-        <S.ProfileUserName>{data.username}</S.ProfileUserName>
-        <S.PofileUserId>&#64;{data.accountname} </S.PofileUserId>
-        <S.ProfileIntroduce>{data.intro}</S.ProfileIntroduce>
+        <S.ProfileUserName>{profileInfo.username}</S.ProfileUserName>
+        <S.PofileUserId>&#64;{profileInfo.accountname} </S.PofileUserId>
+        <S.ProfileIntroduce>{profileInfo.intro}</S.ProfileIntroduce>
         {isMyProfile ? (
-          <TopSectionMy {...data} />
+          <TopSectionMy {...profileInfo} />
         ) : (
           <TopSectionYour
-            isfollow={data.isfollow}
-            userAccountName={data.accountname}
-            setProfile={setData}
+            isfollow={profileInfo.isfollow}
+            userAccountName={profileInfo.accountname}
+            setProfile={setProfileInfo}
           />
         )}
       </S.ProfileTopContainer>

--- a/src/pages/Search/index.jsx
+++ b/src/pages/Search/index.jsx
@@ -10,7 +10,7 @@ import { useGetData } from "../../hooks/useGetData";
 import * as S from "./style";
 
 export default function Search() {
-  const { data, getData } = useGetData();
+  const { data: searchData, getData: getSearchData } = useGetData();
 
   const [searchInputVal, setSearchInputVal] = useState("");
   const url = `${process.env.REACT_APP_API_KEY}/user/searchuser/?keyword=${searchInputVal}`;
@@ -18,7 +18,7 @@ export default function Search() {
   useEffect(() => {
     if (searchInputVal !== "") {
       const timeId = setTimeout(() => {
-        getData(url);
+        getSearchData(url);
       }, 300);
       return () => {
         clearTimeout(timeId);
@@ -36,8 +36,8 @@ export default function Search() {
       </Header>
       <MainContainer>
         <S.UserInfoContainer>
-          {data &&
-            data.map((search) => {
+          {searchData &&
+            searchData.map((search) => {
               return (
                 <Link key={search._id} to={`/profile/${search.accountname}`}>
                   <UserInfo {...search} />


### PR DESCRIPTION
## 🔖 PR 사유

- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [x] 리팩토링 : 홈, 프로필, 검색, 팔로우의 데이터 변수명 변경
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

<br>


## 📂 작업 대상 파일

- src/pages/Follow/index.jsx
- src/pages/Home/index.jsx
- src/pages/Profile/BottomSection.jsx
- src/pages/Profile/MidSection.jsx
- src/pages/Profile/TopSection.jsx
- src/pages/Search/index.jsx

<br>

## 📖 작업 내용

- 홈, 프로필, 검색, 팔로우의 데이터 변수명 변경


<br>


## 🍀 결과물 스크린샷 (이미지 첨부)

<img width="544" alt="image" src="https://user-images.githubusercontent.com/84954439/213846427-9c6b654e-638b-4ae6-bcab-844bc987ded0.png">


<br><br>


## ❔질문사항

- 

<br><br>


## 📌 제안사항

- 
